### PR TITLE
Update device_type inference logic

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -332,8 +332,8 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
     grid_2 = grid[2] if grid_size > 2 else 1
 
     device_types = [device_type for device_type in {device_types} if device_type != '']
-    device_type = self._conclude_device_type(device_types, {pinned_memory_flags})
-    device_backend = None
+    device_type = self._conclude_device_type(device_types, {pinned_memory_flags}) if device is None else device
+    device_backend = device
     if device_type not in ['cuda', 'hip']:
         device_backend = get_backend(device_type)
         if device_backend is None:


### PR DESCRIPTION
The kernel should take care of the `device` argument.
When ther user call `kernel.warmup(torch.float32, device=device_backend)`,  the warmup function will call below:

```
def warmup(self, *args, **kwargs):
      return self.run(*map(MockTensor.wrap_dtype, args), **kwargs, warmup=True)
```

This MockTensor does not have any infomation for the `device`, thus , current code will infer the `device_type` as `cuda` because there is no valid tensor with device type.

This PR ensures that the user given `device` will be set.